### PR TITLE
fix: change @grpc/grpc-js to a peer dependency

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -17,9 +17,11 @@
     "David Moore <david.moore@nitric.io>"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "^1.1.7",
     "google-protobuf": "3.14.0",
     "tslib": "^2.1.0"
+  },
+  "peerDependencies": {
+    "@grpc/grpc-js": "1.x"
   },
   "devDependencies": {
     "@types/google-protobuf": "3.2.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -23,13 +23,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@grpc/grpc-js@^1.1.7":
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.7.tgz#58b687aff93b743aafde237fd2ee9a3259d7f2d8"
-  integrity sha512-CKQVuwuSPh40tgOkR7c0ZisxYRiN05PcKPW72mQL5y++qd7CwBRoaJZvU5xfXnCJDFBmS3qZGQ71Frx6Ofo2XA==
-  dependencies:
-    "@types/node" ">=12.12.47"
-
 "@mapbox/node-pre-gyp@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
@@ -76,7 +69,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@>=12.12.47", "@types/node@^16.9.0":
+"@types/node@^16.9.0":
   version "16.9.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==


### PR DESCRIPTION
This should allow more control of the specific grpc version in SDKs built on this base